### PR TITLE
Fixed README and .gitmodules to use HTTPS URLs.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/ublox"]
 	path = src/ublox
-	url = git@github.com:KumarRobotics/ublox.git
+	url = https://github.com/KumarRobotics/ublox.git

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo apt-get install git
 
   ```
   cd ~
-  git clone git@github.com:BCLab-UNM/Swarmathon-ROS.git
+  git clone https://github.com/BCLab-UNM/Swarmathon-ROS.git
   ```
 
 2. Rename the downloaded repo so it can be properly identified by ROS and catkin:


### PR DESCRIPTION
This pull request fixes problems with the README and .gitmodules so that they can be followed exactly by people who don't have SSH keys registered with github. 