### PR TITLE
Cleanup rogue nodes on exit.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,7 @@ roscore &
 sleep 2
 rqt -s rqt_rover_gui
 echo Cleaning up ROS and Gazebo Processes
+rosnode kill -a 
 echo Killing rosmaster
 pkill rosmaster
 echo Killing roscore


### PR DESCRIPTION
Hello again! The existing run.sh script leaves some ROS nodes behind after it exits. This seems to fix it. As you can tell, I'm having fun. 