### PR TITLE
Corrected a simulated timer issue

### DIFF
--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -1806,6 +1806,7 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
     timer_start_time_in_seconds = 0.0;
     timer_stop_time_in_seconds = 0.0;
     current_simulated_time_in_seconds = 0.0;
+    last_current_time_update_in_seconds = 0.0;
     is_timer_on = false;
 }
 


### PR DESCRIPTION
where the timer does not reset properly when a simulation is cleared
and then rebuilt.

bug: simulated timer does not display the time after re-creating a sim

fix: add "last_current_time_update_in_seconds = 0;" to the clear simulation
     button event handler so that the time displays properly

The problem was that without reseting this variable, the new simulation
waited until the last update time from the OLD simulation to update the
value in the current simulation time label.