### PR TITLE
hotfix-1.2.12 updated the april cube's mass in the model file

### DIFF
--- a/simulation/models/at0/model.sdf
+++ b/simulation/models/at0/model.sdf
@@ -4,7 +4,7 @@
 		<static>false</static>
 		<link name='link'>
 			<inertial>
-				<mass>0.1</mass>
+				<mass>0.01</mass>
 				<inertia>
 					<ixx>0.00004</ixx>
 					<ixy>0.0</ixy>


### PR DESCRIPTION
The mass of the cube in the model.sdf file was not set properly and
has been changed to the correct value.

original mass = 0.1
new mass = 0.01

A side effect of this mass difference was that it caused the simulation
to slow down considerably.

This bug only occurs when creating customized worlds because the prebuilt
worlds used a different file for setting up cubes with the correct mass value.