### PR TITLE
Bug fix: Prevent division by zero in PickupController

### DIFF
--- a/src/mobility/src/PickUpController.cpp
+++ b/src/mobility/src/PickUpController.cpp
@@ -142,13 +142,14 @@ PickUpResult PickUpController::selectTarget(const apriltags_ros::AprilTagDetecti
             target = i;
             closest = test;
             blockDist = hypot(tagPose.pose.position.z, tagPose.pose.position.y); //distance from bottom center of chassis ignoring height.
-            if (0 < (blockDist*blockDist - 0.195*0.195))
+            if (0 <= (blockDist*blockDist - 0.195*0.195))
             {
                 blockDist = sqrt(blockDist*blockDist - 0.195*0.195);
             }
             else
             {
-                blockDist = 0;
+	      float epsilon = 0.00001; // A small non-zero number
+	      blockDist = epsilon;
             }
             blockYawError = atan((tagPose.pose.position.x + 0.020)/blockDist)*1.05; //angle to block from bottom center of chassis on the horizontal.
         }


### PR DESCRIPTION
There is a potential division by zero. This fix replaces zero by a small positive value.