### PR TITLE
Bug fix: fixed typo where x coord set to zero

### DIFF
--- a/src/mobility/src/mobility.cpp
+++ b/src/mobility/src/mobility.cpp
@@ -473,7 +473,7 @@ void mobilityStateMachine(const ros::TimerEvent&) {
                     goalLocation.theta = atan2(centerLocationOdom.y - currentLocation.y, centerLocationOdom.x - currentLocation.x);
 
                     // set center as goal position
-                    goalLocation.x = centerLocationOdom.x = 0;
+                    goalLocation.x = centerLocationOdom.x;
                     goalLocation.y = centerLocationOdom.y;
 
                     // lower wrist to avoid ultrasound sensors


### PR DESCRIPTION
When setting the goal location in odometry to return to the collection point the x coordinate is always set to zero due to a typo.