### PR TITLE
Hotfix 1.2.23  Fixed Yaw PID Integral

### DIFF
--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -323,8 +323,8 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   //only use integral when error is larger than presumed noise.
   if (yawError[0] > yawIntegralDeadspace || yawError[0] < -yawIntegralDeadspace)
   {
-    evArray[stepV] = velError[0]; //add error into the error Array.
-    stepV++;
+    eyArray[stepY] = yawError[0]; //add error into the error Array.
+    stepY++;
     
     if (stepY >= histArrayLength) stepY = 0;
     

--- a/src/mobility/src/mobility.cpp
+++ b/src/mobility/src/mobility.cpp
@@ -392,7 +392,7 @@ void mobilityStateMachine(const ros::TimerEvent&) {
             // If angle > 0.4 radians rotate but dont drive forward.
             if (fabs(angles::shortest_angular_distance(currentLocation.theta, goalLocation.theta)) > rotateOnlyAngleTolerance) {
                 // rotate but dont drive  0.05 is to prevent turning in reverse
-                sendDriveCommand(0.05, errorYaw);
+                sendDriveCommand(0.0, errorYaw);
                 break;
             } else {
                 // move to differential drive step


### PR DESCRIPTION
The Integral error for yaw was being stored in the array for linear velocity
This will fix the linear moment when giving rotate only commands and allow for increased heading accuracy that was being lost.